### PR TITLE
Fix Stack Overflow anchor tags to include plug-react and react.

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ Here are some alternative ways to get help from the Croct community.
 Someone else from the community may have already asked a similar question or may be able to help with your problem.
 
 The Croct team will also monitor posts with the "croct" tag. If there aren't any existing questions that help,
-please [ask a new one](https://stackoverflow.com/questions/ask?tags=croct%20export).
+please [ask a new one](https://stackoverflow.com/questions/ask?tags=croct%20plug-react%20react).
 
 ### GitHub
 


### PR DESCRIPTION
## Summary

Fix Stack Overflow anchor tags to include plug-react and react.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings