### PR TITLE
Add audit resolution to the security check CI

### DIFF
--- a/.github/workflows/branch-validations.yaml
+++ b/.github/workflows/branch-validations.yaml
@@ -32,7 +32,9 @@ jobs:
         run: npm ci
 
       - name: Check dependency vulnerabilities
-        run: npm audit
+        run: |-
+          npm i -g npm-audit-resolver
+          npx check-audit
 
   validate:
     runs-on: ubuntu-18.04

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -1,0 +1,451 @@
+{
+  "decisions": {
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>autoprefixer>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619109,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>autoprefixer>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>autoprefixer>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss-modules-local-by-default>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-local-by-default>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-local-by-default>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss-modules-local-by-default>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619110,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss-modules-local-by-default>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss-modules-values>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-values>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-values>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss-modules-values>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss-modules-values>icss-utils>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss-modules-extract-imports>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-extract-imports>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-extract-imports>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss-modules-extract-imports>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss-modules-extract-imports>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss-modules-local-by-default>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619111,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-local-by-default>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-local-by-default>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss-modules-local-by-default>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss-modules-local-by-default>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss-modules-scope>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-scope>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-scope>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss-modules-scope>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss-modules-scope>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>css-loader>postcss-modules-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>css-loader>postcss-modules-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>css-loader>postcss-modules-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>css-loader>postcss-modules-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>postcss-flexbugs-fixes>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>postcss-flexbugs-fixes>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>postcss-flexbugs-fixes>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>css-declaration-sorter>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619112,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>cssnano-util-raw-cache>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-calc>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-colormin>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-convert-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-discard-comments>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-discard-duplicates>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-discard-empty>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-discard-overridden>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-merge-longhand>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-merge-longhand>stylehacks>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-merge-rules>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-minify-font-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-minify-gradients>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-minify-params>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-minify-selectors>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-charset>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-display-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-positions>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-repeat-style>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-string>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-timing-functions>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-unicode>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619113,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-url>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-normalize-whitespace>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-ordered-values>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-reduce-initial>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-reduce-transforms>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-svgo>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>cssnano-preset-default>postcss-unique-selectors>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1693|microbundle>rollup-plugin-postcss>cssnano>postcss": {
+      "decision": "ignore",
+      "madeAt": 1622229619114,
+      "expiresAt": 1624821593444
+    },
+    "1700|@storybook/addon-essentials>@storybook/addon-docs>@mdx-js/loader>@mdx-js/mdx>remark-mdx>remark-parse>trim": {
+      "decision": "ignore",
+      "madeAt": 1622229632110,
+      "expiresAt": 1624821593444
+    },
+    "1700|@storybook/addon-essentials>@storybook/addon-docs>@mdx-js/mdx>remark-mdx>remark-parse>trim": {
+      "decision": "ignore",
+      "madeAt": 1622229632110,
+      "expiresAt": 1624821593444
+    },
+    "1700|@storybook/addon-essentials>@storybook/addon-docs>@mdx-js/loader>@mdx-js/mdx>remark-parse>trim": {
+      "decision": "ignore",
+      "madeAt": 1622229632110,
+      "expiresAt": 1624821593444
+    },
+    "1700|@storybook/addon-essentials>@storybook/addon-docs>@mdx-js/mdx>remark-parse>trim": {
+      "decision": "ignore",
+      "madeAt": 1622229632110,
+      "expiresAt": 1624821593444
+    },
+    "1747|@storybook/addon-essentials>@storybook/addon-docs>@storybook/builder-webpack4>react-dev-utils>browserslist": {
+      "decision": "ignore",
+      "madeAt": 1622229638570,
+      "expiresAt": 1624821593444
+    },
+    "1747|@storybook/addon-essentials>@storybook/addon-docs>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>react-dev-utils>browserslist": {
+      "decision": "ignore",
+      "madeAt": 1622229638570,
+      "expiresAt": 1624821593444
+    },
+    "1747|@storybook/react>@storybook/core>@storybook/core-server>@storybook/builder-webpack4>react-dev-utils>browserslist": {
+      "decision": "ignore",
+      "madeAt": 1622229638570,
+      "expiresAt": 1624821593444
+    },
+    "1747|@storybook/react>react-dev-utils>browserslist": {
+      "decision": "ignore",
+      "madeAt": 1622229638570,
+      "expiresAt": 1624821593444
+    }
+  },
+  "rules": {},
+  "version": 1
+}


### PR DESCRIPTION
## Summary
Add audit vulnerability resolution to the security check workflow. This allows us to "mute" alerts regarding vulnerabilities that have not been fixed yet, but that we confirmed do not affect us.