### PR TITLE
Fix Plug initialization on server-side

### DIFF
--- a/src/hooks/useCroct.ssr.test.tsx
+++ b/src/hooks/useCroct.ssr.test.tsx
@@ -1,0 +1,18 @@
+import {renderHook} from '@testing-library/react-hooks/server';
+import {ReactNode} from 'react';
+import {useCroct} from './useCroct';
+import {CroctProvider} from '../CroctProvider';
+
+describe('useCroct', () => {
+    it('should not fail on server-side rendering', () => {
+        const {result} = renderHook(() => useCroct(), {
+            wrapper: ({children}: {children?: ReactNode}) => (
+                <CroctProvider appId="00000000-0000-0000-0000-000000000000">
+                    {children}
+                </CroctProvider>
+            ),
+        });
+
+        expect(result.error).toBeUndefined();
+    });
+});

--- a/src/ssr-polyfills.ssr.test.ts
+++ b/src/ssr-polyfills.ssr.test.ts
@@ -19,6 +19,14 @@ describe('Croct polyfill (SSR)', () => {
         expect(croct.unplug).not.toHaveBeenCalled();
     });
 
+    it('should not initialize', () => {
+        expect(croctPolyfill.initialized).toBe(false);
+
+        croctPolyfill.plug({appId: '00000000-0000-0000-0000-000000000000'});
+
+        expect(croctPolyfill.initialized).toBe(false);
+    });
+
     it('should not allow accessing properties other than plug or unplug', () => {
         expect(() => croctPolyfill.user)
             .toThrow('Property croct.user is not supported on server-side (SSR).');

--- a/src/ssr-polyfills.ts
+++ b/src/ssr-polyfills.ts
@@ -5,8 +5,11 @@ export function isSsr(): boolean {
 }
 
 export const croct: Plug = !isSsr() ? csrPlug : new Proxy(csrPlug, {
-    get(_, property) {
+    get(_, property: keyof Plug) {
         switch (property) {
+            case 'initialized':
+                return false;
+
             case 'plug':
                 return () => {
                     // no-op


### PR DESCRIPTION
## Summary
The SSR polyfill isn't handling the `initialized` property that is checked both on the client-side and server-side initialization.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings