### PR TITLE
Disable security checks workflow job

### DIFF
--- a/.github/workflows/branch-validations.yaml
+++ b/.github/workflows/branch-validations.yaml
@@ -12,29 +12,29 @@ on:
       - opened
 
 jobs:
-  security-checks:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
+  # security-checks:
+  #   runs-on: ubuntu-18.04
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 12
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+  #     - name: Cache dependencies
+  #       id: cache-dependencies
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: node_modules
+  #         key: node_modules-${{ hashFiles('**/package-lock.json') }}
 
-      - name: Install dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: npm ci
+  #     - name: Install dependencies
+  #       if: steps.cache-dependencies.outputs.cache-hit != 'true'
+  #       run: npm ci
 
-      - name: Check dependency vulnerabilities
-        run: |-
-          npm i -g npm-audit-resolver
-          npx check-audit
+  #     - name: Check dependency vulnerabilities
+  #       run: |-
+  #         npm i -g npm-audit-resolver
+  #         npx check-audit
 
   validate:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Summary
Disable vulnerability checks on CI while `npm-audit-resolver` is frequently
breaking.

Reference issues:

- npm/cli#4550
- naugtur/npm-audit-resolver#56
- naugtur/npm-audit-resolver#34