### PR TITLE
Fix deploy release action

### DIFF
--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -35,8 +35,9 @@ jobs:
         run: |-
           cp package.json LICENSE README.md build/
           cd build
+          jq package.json '.devDependencies = {}' > ./package.json
           sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json
-          sed -i -e "s~./build/~./~" package.json
+          sed -i -e "s~\./build~.~" package.json
           sed -i -e "s~./src~.~" package.json
 
       - name: Publish pre-release to NPM

--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Prepare release
         run: |-
-          cp package.json LICENSE README.md build/
+          cp LICENSE README.md build/
+          jq package.json '.devDependencies = {}' > ./build/package.json
           cd build
-          jq package.json '.devDependencies = {}' > ./package.json
           sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json
           sed -i -e "s~\./build~.~" package.json
           sed -i -e "s~./src~.~" package.json

--- a/.github/workflows/deploy-published-releases.yaml
+++ b/.github/workflows/deploy-published-releases.yaml
@@ -36,7 +36,7 @@ jobs:
           cp package.json LICENSE README.md build/
           cd build
           sed -i -e "s~\"version\": \"0.0.0-dev\"~\"version\": \"${GITHUB_REF##*/}\"~" package.json
-          sed -i -e "s~./build~.~" package.json
+          sed -i -e "s~./build/~./~" package.json
           sed -i -e "s~./src~.~" package.json
 
       - name: Publish pre-release to NPM


### PR DESCRIPTION
## Summary

Change the release action regex to be more strict about the places where it should update the word `build`.

With the previous regex, the `@storybook/builder-webpack5` package was being updated to `@storyboo.er-webpack5`, which has caused an error on the publish step.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings