### PR TITLE
fix: rename all 'home-banner@1' to 'home-banner'

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ export default function HomePage(): ReactElement {
 ```
 
 You can specify the version of the slot by passing a versioned ID in the form `id@version`. For example,
-passing `home-banner@1` will fetch the content for the `home-banner` slot in version 1. Not specifying a
+passing `home-banner` will fetch the content for the `home-banner` slot in version 1. Not specifying a
 version number is the same as passing `home-banner@latest`, which will load the latest version of the slot.
 
 > ✅ Best practice  

--- a/examples/csr-app/src/components/HomeBanner/index.test.tsx
+++ b/examples/csr-app/src/components/HomeBanner/index.test.tsx
@@ -37,7 +37,7 @@ describe('<HomeBanner />', () => {
             </CroctProvider>,
         );
 
-        expect(fetchContent).toHaveBeenCalledWith('home-banner@1', {});
+        expect(fetchContent).toHaveBeenCalledWith('home-banner', {});
 
         expect(screen.getByText('Experience up to 20% more revenue faster')).toBeInTheDocument();
 
@@ -66,7 +66,7 @@ describe('<HomeBanner />', () => {
 
         await act(flushPromises);
 
-        expect(fetchContent).toHaveBeenCalledWith('home-banner@1', {});
+        expect(fetchContent).toHaveBeenCalledWith('home-banner', {});
 
         expect(screen.getByText('Experience up to 20% more revenue faster')).toBeInTheDocument();
 

--- a/examples/csr-app/src/components/HomeBanner/index.tsx
+++ b/examples/csr-app/src/components/HomeBanner/index.tsx
@@ -2,7 +2,7 @@ import {ReactElement} from 'react';
 import {Slot, SlotContent} from '@croct/plug-react';
 import './style.css';
 
-const SLOT_ID = 'home-banner@1';
+const SLOT_ID = 'home-banner';
 
 type SlotProps = SlotContent<typeof SLOT_ID> & {
     loading?: boolean,

--- a/examples/next-csr-app/components/HomeBanner.test.tsx
+++ b/examples/next-csr-app/components/HomeBanner.test.tsx
@@ -46,7 +46,7 @@ describe('<HomeBanner />', () => {
             </CroctProvider>,
         );
 
-        expect(fetchContent).toHaveBeenCalledWith('home-banner@1', {});
+        expect(fetchContent).toHaveBeenCalledWith('home-banner', {});
 
         expect(screen.getByText('Experience up to 20% more revenue faster')).toBeInTheDocument();
 
@@ -75,7 +75,7 @@ describe('<HomeBanner />', () => {
 
         await act(flushPromises);
 
-        expect(fetchContent).toHaveBeenCalledWith('home-banner@1', {});
+        expect(fetchContent).toHaveBeenCalledWith('home-banner', {});
 
         expect(screen.getByText('Experience up to 20% more revenue faster')).toBeInTheDocument();
 

--- a/examples/next-csr-app/components/HomeBanner.tsx
+++ b/examples/next-csr-app/components/HomeBanner.tsx
@@ -2,7 +2,7 @@ import {ReactElement} from 'react';
 import {Slot, SlotContent} from '@croct/plug-react';
 import {fetchStaticContent} from '@/lib/utils/fetchStaticContent';
 
-const SLOT_ID = 'home-banner@1';
+const SLOT_ID = 'home-banner';
 
 type HomeBannerSlotProps = SlotContent<typeof SLOT_ID> & {
     loading?: boolean,

--- a/examples/next-ssr-app/components/HomeBanner.test.tsx
+++ b/examples/next-ssr-app/components/HomeBanner.test.tsx
@@ -16,7 +16,7 @@ describe('<HomeBanner />', () => {
         jest.clearAllMocks();
     });
 
-    const content: SlotContent<'home-banner@1'> = {
+    const content: SlotContent<'home-banner'> = {
         title: 'Title',
         subtitle: 'Subtitle',
         cta: {
@@ -31,7 +31,7 @@ describe('<HomeBanner />', () => {
         // Jest does not support async component rendering yet
         render(await HomeBanner());
 
-        expect(fetchContent).toHaveBeenCalledWith('home-banner@1', {
+        expect(fetchContent).toHaveBeenCalledWith('home-banner', {
             fallback: {
                 title: 'Experience up to 20% more revenue faster',
                 subtitle: 'Deliver tailored experiences that drive satisfaction and growth.',
@@ -55,7 +55,7 @@ describe('preloadHomeBanner', () => {
     it('should preload the personalized content', () => {
         preloadHomeBanner();
 
-        expect(fetchContent).toHaveBeenCalledWith('home-banner@1', {
+        expect(fetchContent).toHaveBeenCalledWith('home-banner', {
             fallback: {
                 title: 'Experience up to 20% more revenue faster',
                 subtitle: 'Deliver tailored experiences that drive satisfaction and growth.',

--- a/examples/next-ssr-app/components/HomeBanner.tsx
+++ b/examples/next-ssr-app/components/HomeBanner.tsx
@@ -2,7 +2,7 @@ import {ReactElement} from 'react';
 import {SlotContent} from '@croct/plug-react';
 import {fetchContent} from '@/lib/utils/fetchContent';
 
-const SLOT_ID = 'home-banner@1';
+const SLOT_ID = 'home-banner';
 
 function loadHomeBanner(): Promise<SlotContent<typeof SLOT_ID>> {
     return fetchContent(SLOT_ID, {

--- a/examples/next-ssr-app/lib/utils/fetchContent.test.ts
+++ b/examples/next-ssr-app/lib/utils/fetchContent.test.ts
@@ -25,7 +25,7 @@ jest.mock(
 
 describe('fetchContent', () => {
     const {env} = process;
-    const slotId: VersionedSlotId = 'home-banner@1';
+    const slotId: VersionedSlotId = 'home-banner';
     const API_KEY = '00000000-0000-0000-0000-000000000000';
     const options: FetchOptions<SlotContent<typeof slotId>> = {
         timeout: 100,

--- a/src/hooks/useContent.test.ts
+++ b/src/hooks/useContent.test.ts
@@ -29,7 +29,7 @@ describe('useContent (CSR)', () => {
         jest.mocked(useCroct).mockReturnValue({fetch: fetch} as Plug);
         jest.mocked(useLoader).mockReturnValue('foo');
 
-        const slotId = 'home-banner@1';
+        const slotId = 'home-banner';
 
         const {result} = renderHook(
             () => useContent<{title: string}>(slotId, {


### PR DESCRIPTION
## Summary

the example codebase was giving an error with the slot id
![Screenshot 2023-05-11 at 12 45 01](https://github.com/croct-tech/plug-react/assets/39449389/1f5dc8bd-728c-40f4-bd2d-09781d33c3f2)

white screen
![Screenshot 2023-05-11 at 12 55 28](https://github.com/croct-tech/plug-react/assets/39449389/5e4fedb8-e72e-46c5-ad1a-8760e3abb1cb)
