### PR TITLE
Implement preferredLocale on the CroctProvider

### DIFF
--- a/src/CroctProvider.test.tsx
+++ b/src/CroctProvider.test.tsx
@@ -47,6 +47,7 @@ describe('<CroctProvider />', () => {
             appId: '00000000-0000-0000-0000-000000000000',
             debug: true,
             track: true,
+            preferredLocale: 'en-us',
         };
 
         let initialized = false;
@@ -74,9 +75,24 @@ describe('<CroctProvider />', () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
 
+        expect(callback).toHaveBeenCalledWith({
+            plug: expect.any(Object),
+            preferredLocale: options.preferredLocale,
+        });
+
         expect(croct.plug).toHaveBeenCalledTimes(2);
-        expect(croct.plug).toHaveBeenNthCalledWith(1, options);
-        expect(croct.plug).toHaveBeenNthCalledWith(2, options);
+
+        expect(croct.plug).toHaveBeenNthCalledWith(1, {
+            appId: options.appId,
+            debug: options.debug,
+            track: options.track,
+        });
+
+        expect(croct.plug).toHaveBeenNthCalledWith(2, {
+            appId: options.appId,
+            debug: options.debug,
+            track: options.track,
+        });
     });
 
     it('should unplug on unmount', () => {

--- a/src/CroctProvider.tsx
+++ b/src/CroctProvider.tsx
@@ -14,9 +14,16 @@ import {
 import {Configuration, Plug} from '@croct/plug';
 import {croct} from './ssr-polyfills';
 
-export type CroctProviderProps = PropsWithChildren<Configuration & Required<Pick<Configuration, 'appId'>>>;
+export type CroctProviderProps = PropsWithChildren<Configuration
+    & Required<Pick<Configuration, 'appId'>>>
+    & Pick<CroctState, 'preferredLocale'>;
 
-export const CroctContext = createContext<{plug: Plug}|null>(null);
+export type CroctState = {
+    plug: Plug,
+    preferredLocale?: string,
+};
+
+export const CroctContext = createContext<CroctState | null>(null);
 CroctContext.displayName = 'CroctContext';
 
 function useLiveRef<T>(value: T): MutableRefObject<T> {
@@ -28,7 +35,7 @@ function useLiveRef<T>(value: T): MutableRefObject<T> {
 }
 
 export const CroctProvider: FunctionComponent<CroctProviderProps> = (props): ReactElement => {
-    const {children, ...configuration} = props;
+    const {children, preferredLocale, ...configuration} = props;
     const parent = useContext(CroctContext);
     const baseConfiguration = useLiveRef(configuration);
 
@@ -41,6 +48,7 @@ export const CroctProvider: FunctionComponent<CroctProviderProps> = (props): Rea
 
     const context = useMemo(
         () => ({
+            preferredLocale: preferredLocale,
             get plug(): Plug {
                 if (!croct.initialized) {
                     croct.plug(baseConfiguration.current);
@@ -59,7 +67,7 @@ export const CroctProvider: FunctionComponent<CroctProviderProps> = (props): Rea
                 });
             },
         }),
-        [baseConfiguration],
+        [baseConfiguration, preferredLocale],
     );
 
     useEffect(

--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -17,11 +17,19 @@ function useCsrContent<I, F>(
     options: UseContentOptions<I, F> = {},
 ): SlotContent | I | F {
     const {fallback, initial, cacheKey, expiration, ...fetchOptions} = options;
-    const croct = useCroct();
+    const {preferredLocale, plug} = useCroct();
 
     return useLoader({
         cacheKey: `useContent:${cacheKey ?? ''}:${id}`,
-        loader: () => croct.fetch(id, fetchOptions).then(({content}) => content),
+        loader: () => (
+            plug.fetch(
+                id,
+                {
+                    ...fetchOptions,
+                    preferredLocale: fetchOptions.preferredLocale ?? preferredLocale,
+                },
+            ).then(({content}) => content)
+        ),
         initial: initial,
         fallback: fallback,
         expiration: expiration,

--- a/src/hooks/useCroct.test.tsx
+++ b/src/hooks/useCroct.test.tsx
@@ -14,13 +14,19 @@ describe('useCroct', () => {
         expect(console.error).toHaveBeenCalled();
     });
 
-    it('should return the Plug instance', () => {
+    it('should return the croct state', () => {
+        const preferredLocale = 'en-us';
+
         const {result} = renderHook(() => useCroct(), {
             wrapper: ({children}) => (
-                <CroctContext.Provider value={{plug: croct}}>{children}</CroctContext.Provider>
+                <CroctContext.Provider value={{plug: croct, preferredLocale: preferredLocale}}>
+                    {children}
+                </CroctContext.Provider>
             ),
         });
 
-        expect(result.current).toBe(croct);
+        expect(result.current.plug).toBe(croct);
+
+        expect(result.current.preferredLocale).toBe(preferredLocale);
     });
 });

--- a/src/hooks/useCroct.ts
+++ b/src/hooks/useCroct.ts
@@ -1,13 +1,12 @@
-import {Plug} from '@croct/plug';
 import {useContext} from 'react';
-import {CroctContext} from '../CroctProvider';
+import {CroctContext, CroctState} from '../CroctProvider';
 
-export function useCroct(): Plug {
+export function useCroct(): CroctState {
     const context = useContext(CroctContext);
 
     if (context === null) {
         throw new Error('useCroct() can only be used in the context of a <CroctProvider> component.');
     }
 
-    return context.plug;
+    return context;
 }

--- a/src/hooks/useEvaluation.test.ts
+++ b/src/hooks/useEvaluation.test.ts
@@ -35,7 +35,9 @@ describe('useEvaluation', () => {
 
         const evaluate: Plug['evaluate'] = jest.fn();
 
-        jest.mocked(useCroct).mockReturnValue({evaluate: evaluate} as Plug);
+        jest.mocked(useCroct).mockReturnValue({
+            plug: {evaluate: evaluate} as Plug,
+        });
         jest.mocked(useLoader).mockReturnValue('foo');
 
         const query = 'location';
@@ -75,7 +77,9 @@ describe('useEvaluation', () => {
 
         const evaluate: Plug['evaluate'] = jest.fn();
 
-        jest.mocked(useCroct).mockReturnValue({evaluate: evaluate} as Plug);
+        jest.mocked(useCroct).mockReturnValue({
+            plug: {evaluate: evaluate} as Plug,
+        });
         jest.mocked(useLoader).mockReturnValue('foo');
 
         const query = 'location';

--- a/src/hooks/useEvaluation.ts
+++ b/src/hooks/useEvaluation.ts
@@ -37,7 +37,7 @@ function useCsrEvaluation<T = JsonValue, I = T, F = T>(
 
     return useLoader<T | I | F>({
         cacheKey: `useEvaluation:${cacheKey ?? ''}:${query}:${JSON.stringify(options.attributes ?? '')}`,
-        loader: () => croct.evaluate<T & JsonValue>(query, cleanEvaluationOptions(evaluationOptions)),
+        loader: () => croct.plug.evaluate<T & JsonValue>(query, cleanEvaluationOptions(evaluationOptions)),
         initial: initial,
         fallback: fallback,
         expiration: expiration,


### PR DESCRIPTION
## Summary

This PR allows the user to provide the locale directly to the `CroctProvider` component, automatically making its context known to all the slots.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings