### PR TITLE
Fix unmount bug

### DIFF
--- a/src/hooks/useLoader.test.ts
+++ b/src/hooks/useLoader.test.ts
@@ -1,4 +1,5 @@
 import {act, renderHook, waitFor} from '@testing-library/react';
+import {StrictMode} from 'react';
 import {useLoader} from './useLoader';
 
 describe('useLoader', () => {
@@ -403,5 +404,35 @@ describe('useLoader', () => {
         expect(loader).toHaveBeenCalledTimes(2);
 
         await waitFor(() => expect(secondTime.current).toBe('foo'));
+    });
+
+    it('should update the content in StrictMode', async () => {
+        jest.useFakeTimers();
+
+        const delay = 10;
+        const loader = jest.fn(
+            () => new Promise(resolve => {
+                setTimeout(() => resolve('foo'), delay);
+            }),
+        );
+
+        const {result} = renderHook(
+            () => useLoader({
+                cacheKey: cacheKey.current(),
+                loader: loader,
+                initial: 'bar',
+            }),
+            {
+                wrapper: StrictMode,
+            },
+        );
+
+        // Let the loader resolve
+        await act(async () => {
+            jest.advanceTimersByTime(delay);
+            await flushPromises();
+        });
+
+        await waitFor(() => expect(result.current).toBe('foo'));
     });
 });

--- a/src/hooks/useLoader.ts
+++ b/src/hooks/useLoader.ts
@@ -35,6 +35,8 @@ export function useLoader<R>({initial, ...currentOptions}: CacheOptions<R>): R {
 
     useEffect(
         () => {
+            mountedRef.current = true;
+
             if (initial !== undefined) {
                 load(currentOptions);
             }


### PR DESCRIPTION
## Summary
Currently, when using Strict Mode – which causes the component to mount, unmount, and remount during the initial render – the component never updates with the loaded content because the mounted flag is permanently set to false after the first unmount. This PR fixes the issue by resetting the mounted flag to true at the start of each useEffect call, and providing a cleanup callback to set it back to false when the component unmounts.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings