### PR TITLE
Normalize preferred locale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@croct/plug": "^0.17.0",
+        "@croct/plug": "^0.17.1",
         "@croct/sdk": "^0.18.0"
       },
       "devDependencies": {
@@ -853,9 +853,9 @@
       "license": "MIT"
     },
     "node_modules/@croct/plug": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@croct/plug/-/plug-0.17.0.tgz",
-      "integrity": "sha512-v9WnkskOAWem9q011O7NidgWEk9rVxl2qCjFW+Hf11PHgIhtuOUZ5HdjE7n7tpieWqgcY27z86kS8EfXwa34ZA==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@croct/plug/-/plug-0.17.1.tgz",
+      "integrity": "sha512-SWcTHpIg+he1LhrtzlX50/n9pwSVRZqXJ56xp5J1velvplB1xgznov/bZzPwU/+rEHL0YEj2466mjEk7x82/rg==",
       "license": "MIT",
       "dependencies": {
         "@croct/content": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@croct/plug": "^0.17.0",
+    "@croct/plug": "^0.17.1",
     "@croct/sdk": "^0.18.0"
   },
   "devDependencies": {

--- a/src/hooks/useContent.ssr.test.ts
+++ b/src/hooks/useContent.ssr.test.ts
@@ -64,4 +64,21 @@ describe('useContent (SSR)', () => {
 
         expect(result.current).toBe(initial);
     });
+
+    it('should normalize an empty preferred locale to undefined', () => {
+        const slotId = 'slot-id';
+        const preferredLocale = '';
+
+        jest.mocked(getSlotContent).mockReturnValue({
+            foo: 'bar',
+        });
+
+        renderHook(
+            () => useContent(slotId, {
+                preferredLocale: preferredLocale,
+            }),
+        );
+
+        expect(getSlotContent).toHaveBeenCalledWith(slotId, undefined);
+    });
 });

--- a/src/hooks/useContent.test.ts
+++ b/src/hooks/useContent.test.ts
@@ -290,4 +290,27 @@ describe('useContent (CSR)', () => {
             preferredLocale: preferredLocale,
         });
     });
+
+    it('should normalize an empty preferred locale to undefined', () => {
+        const fetch: Plug['fetch'] = jest.fn().mockResolvedValue({
+            content: {},
+        });
+
+        jest.mocked(useCroct).mockReturnValue({fetch: fetch} as Plug);
+
+        renderHook(
+            () => useContent('slot-id', {
+                preferredLocale: '',
+            }),
+        );
+
+        jest.mocked(useLoader)
+            .mock
+            .calls[0][0]
+            .loader();
+
+        expect(fetch).toHaveBeenCalledWith('slot-id', {
+            preferredLocale: undefined,
+        });
+    });
 });

--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -28,7 +28,7 @@ function useCsrContent<I, F>(
         ...fetchOptions
     } = options;
 
-    const {preferredLocale} = fetchOptions;
+    const preferredLocale = normalizePreferredLocale(fetchOptions.preferredLocale);
     const defaultContent = useMemo(
         () => getSlotContent(id, preferredLocale) as SlotContent|null ?? undefined,
         [id, preferredLocale],
@@ -47,7 +47,11 @@ function useCsrContent<I, F>(
             + `:${preferredLocale ?? ''}`
             + `:${JSON.stringify(fetchOptions.attributes ?? {})}`,
         ),
-        loader: () => croct.fetch(id, {...fetchOptions, fallback: fallback}).then(({content}) => content),
+        loader: () => croct.fetch(id, {
+            ...fetchOptions,
+            preferredLocale: preferredLocale,
+            fallback: fallback,
+        }).then(({content}) => content),
         initial: initial,
         expiration: expiration,
     });
@@ -75,7 +79,7 @@ function useSsrContent<I, F>(
     {initial, preferredLocale}: UseContentOptions<I, F> = {},
 ): SlotContent | I | F {
     const resolvedInitialContent = initial === undefined
-        ? getSlotContent(slotId, preferredLocale) as I|null ?? undefined
+        ? getSlotContent(slotId, normalizePreferredLocale(preferredLocale)) as I|null ?? undefined
         : initial;
 
     if (resolvedInitialContent === undefined) {
@@ -86,6 +90,10 @@ function useSsrContent<I, F>(
     }
 
     return resolvedInitialContent;
+}
+
+function normalizePreferredLocale(preferredLocale: string|undefined): string|undefined {
+    return preferredLocale !== undefined && preferredLocale !== '' ? preferredLocale : undefined;
 }
 
 type UseContentHook = {


### PR DESCRIPTION
## Summary
This PR normalizes preferred locales passed as empty strings to undefined, simplifying prop drilling. The Next.js SDK now exposes the getPreferredLocale function, which returns the preferred locale for a given route. Since the preferred locale may be unknown, this method could return either an empty string or null. However, returning null would require additional handling (e.g., using a null coalescing operator), as all consuming code expects either a string or undefined.

To avoid this, the method returns an empty string when no locale is specified. To ensure consistency across SDKs, this change is also being applied to the React SDK.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings