### PR TITLE
Prevent forwarding undefined options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@croct/plug": "^0.17.1",
+        "@croct/plug": "^0.17.2",
         "@croct/sdk": "^0.18.0"
       },
       "devDependencies": {
@@ -853,9 +853,9 @@
       "license": "MIT"
     },
     "node_modules/@croct/plug": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@croct/plug/-/plug-0.17.1.tgz",
-      "integrity": "sha512-SWcTHpIg+he1LhrtzlX50/n9pwSVRZqXJ56xp5J1velvplB1xgznov/bZzPwU/+rEHL0YEj2466mjEk7x82/rg==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/@croct/plug/-/plug-0.17.2.tgz",
+      "integrity": "sha512-xJr4z++I4K5D3xDk4K8S8UKL8b/zow3Nc/lZ5rJSxeLS7Xn8vMHKhZv5Rhz5A5KA9iHqu/Q+M4lFBnht6XcrxQ==",
       "license": "MIT",
       "dependencies": {
         "@croct/content": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@croct/plug": "^0.17.1",
+    "@croct/plug": "^0.17.2",
     "@croct/sdk": "^0.18.0"
   },
   "devDependencies": {

--- a/src/hooks/useContent.test.ts
+++ b/src/hooks/useContent.test.ts
@@ -309,8 +309,6 @@ describe('useContent (CSR)', () => {
             .calls[0][0]
             .loader();
 
-        expect(fetch).toHaveBeenCalledWith('slot-id', {
-            preferredLocale: undefined,
-        });
+        expect(jest.mocked(fetch).mock.calls[0][1]).toStrictEqual({});
     });
 });

--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -25,13 +25,14 @@ function useCsrContent<I, F>(
         fallback: fallbackContent,
         initial: initialContent,
         staleWhileLoading = false,
+        preferredLocale,
         ...fetchOptions
     } = options;
 
-    const preferredLocale = normalizePreferredLocale(fetchOptions.preferredLocale);
+    const normalizedLocale = normalizePreferredLocale(preferredLocale);
     const defaultContent = useMemo(
-        () => getSlotContent(id, preferredLocale) as SlotContent|null ?? undefined,
-        [id, preferredLocale],
+        () => getSlotContent(id, normalizedLocale) as SlotContent|null ?? undefined,
+        [id, normalizedLocale],
     );
     const fallback = fallbackContent === undefined ? defaultContent : fallbackContent;
     const [initial, setInitial] = useState<SlotContent | I | F | undefined>(
@@ -44,13 +45,13 @@ function useCsrContent<I, F>(
         cacheKey: hash(
             `useContent:${cacheKey ?? ''}`
             + `:${id}`
-            + `:${preferredLocale ?? ''}`
+            + `:${normalizedLocale ?? ''}`
             + `:${JSON.stringify(fetchOptions.attributes ?? {})}`,
         ),
         loader: () => croct.fetch(id, {
             ...fetchOptions,
-            preferredLocale: preferredLocale,
-            fallback: fallback,
+            ...(normalizedLocale !== undefined ? {preferredLocale: normalizedLocale} : {}),
+            ...(fallback !== undefined ? {fallback: fallback} : {}),
         }).then(({content}) => content),
         initial: initial,
         expiration: expiration,


### PR DESCRIPTION
## Summary
PR #528 introduced an issue because the content fetcher does not accept undefined options. This PR ensures that the preferred locale and fallback value are only forwarded when they are defined.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings