### PR TITLE
Add use-client directive

### DIFF
--- a/src/hooks/useContent.ts
+++ b/src/hooks/useContent.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {SlotContent, VersionedSlotId, VersionedSlotMap} from '@croct/plug/slot';
 import {JsonObject} from '@croct/plug/sdk/json';
 import {FetchOptions} from '@croct/plug/plug';

--- a/src/hooks/useCroct.ts
+++ b/src/hooks/useCroct.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {Plug} from '@croct/plug';
 import {useContext} from 'react';
 import {CroctContext} from '../CroctProvider';

--- a/src/hooks/useEvaluation.ts
+++ b/src/hooks/useEvaluation.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {JsonValue} from '@croct/plug/sdk/json';
 import {EvaluationOptions} from '@croct/sdk/facade/evaluatorFacade';
 import {useEffect, useState} from 'react';


### PR DESCRIPTION
## Summary
Add the `"use client"` directive to all hooks to ensure SSR frameworks don't strip the hook logic from the client side.

In the Next.js SDK, the hook initially returns default content on the server and then requests personalized content on the client. However, if the component using the hook doesn't contain client-only code, Next.js assumes there's no dynamic logic, stripping out the SDK’s functionality from the client-side bundle. This PR explicitly marks the hooks as client code to prevent that behavior.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings