### PR TITLE
Fix import to use named export from Plug package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@croct/plug": "^0.17.2",
+        "@croct/plug": "^0.18.0",
         "@croct/sdk": "^0.18.0"
       },
       "devDependencies": {
@@ -811,7 +811,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@croct/content/-/content-1.1.0.tgz",
       "integrity": "sha512-C8fZq0x+NaCdRHTDrh6UHk7NHFlhU8qloRfe2WjiOB19e2ErJ1Gv8CbE823GSGY5c24AaKsL2clZsXdtxRhB7g==",
-      "license": "MIT",
       "dependencies": {
         "@croct/json": "^2.1.0"
       }
@@ -853,22 +852,20 @@
       "license": "MIT"
     },
     "node_modules/@croct/plug": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/@croct/plug/-/plug-0.17.2.tgz",
-      "integrity": "sha512-xJr4z++I4K5D3xDk4K8S8UKL8b/zow3Nc/lZ5rJSxeLS7Xn8vMHKhZv5Rhz5A5KA9iHqu/Q+M4lFBnht6XcrxQ==",
-      "license": "MIT",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@croct/plug/-/plug-0.18.0.tgz",
+      "integrity": "sha512-5jfn6B6swHCLkdB5DSFQKPPSC9trebw8NsuuEIEzPwe9YaRcwbFEOUuGu7ChLQgdTHal4fnr/DDY6rOjvg3W/g==",
       "dependencies": {
         "@croct/content": "^1.1.0",
         "@croct/json": "^2.1.0",
-        "@croct/sdk": "^0.18.0",
+        "@croct/sdk": "^0.18.1",
         "tslib": "^2.7.0"
       }
     },
     "node_modules/@croct/sdk": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@croct/sdk/-/sdk-0.18.0.tgz",
-      "integrity": "sha512-nYPqYUp2cyL6Qda/ArY5DFav1rcl+gY9VdoNEgqsl9h5hl3fwjSWG4KEmxgmYE8c3sUqmw1X1FTJTJ43+AhKAA==",
-      "license": "MIT",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@croct/sdk/-/sdk-0.18.1.tgz",
+      "integrity": "sha512-RvP9AEWT3/g76mrhjT7Hx4deFO8tXDRTqhMyLr/31EtWkZ/oG6oISeQzVOjKbVmT/Yx+BFq1263U7Q4e5vnAEA==",
       "dependencies": {
         "@croct/json": "^2.0.1",
         "tslib": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
-    "@croct/plug": "^0.17.2",
+    "@croct/plug": "^0.18.0",
     "@croct/sdk": "^0.18.0"
   },
   "devDependencies": {

--- a/src/ssr-polyfills.ts
+++ b/src/ssr-polyfills.ts
@@ -1,4 +1,4 @@
-import csrPlug, {Plug} from '@croct/plug';
+import {plug, Plug} from '@croct/plug';
 
 /**
  * @internal
@@ -16,7 +16,7 @@ export const croct: Plug = !isSsr()
         let resolveCallback: () => void;
         let rejectCallback: (reason: any) => void;
 
-        return new Proxy(csrPlug, {
+        return new Proxy(plug, {
             get: function getProperty(target, property: keyof Plug): any {
                 switch (property) {
                     case 'plug':
@@ -47,7 +47,7 @@ export const croct: Plug = !isSsr()
             },
         });
     }())
-    : new Proxy(csrPlug, {
+    : new Proxy(plug, {
         get: function getProperty(_, property: keyof Plug): any {
             switch (property) {
                 case 'initialized':


### PR DESCRIPTION
## Summary
This PR updates the Plug React code to correctly import croct as a named export instead of accessing it via default.
This change is necessary because the CJS build of the Plug package now exports named modules properly.

Related to: [#337](https://github.com/croct-tech/plug-js/pull/337)

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings