### PR TITLE
Fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
         <source media="(min-width: 769px) and (prefers-color-scheme: dark)" srcset="https://github.com/croct-tech/plug-js/blob/master/.github/assets/header-dark.svg">
         <source media="(max-width: 768px) and (prefers-color-scheme: dark)" srcset="https://github.com/croct-tech/plug-js/blob/master/.github/assets/header-dark-mobile.svg">
         <source media="(max-width: 768px) and (prefers-color-scheme: light)" srcset="https://github.com/croct-tech/plug-js/blob/master/.github/assets/header-light-mobile.svg">
-        <img src="https://raw.githubusercontent.com/croct-tech/plug-js/refs/heads/update-readme/.github/assets/header-light-mobile.svg" alt="Croct React SDK" title="Croct React SDK" width="100%">
+        <img src="https://github.com/croct-tech/plug-js/blob/master/.github/assets/header-light-mobile.svg" alt="Croct React SDK" title="Croct React SDK" width="100%">
     </picture>
   </a>
   <br/>


### PR DESCRIPTION
## Summary

Fixes a broken README link discovered during the `library/plug-*` README link sweep.

## Changes

- Updates the README header fallback image to point at the existing `plug-js` `master` asset instead of the removed `update-readme` branch.

## Testing

- Ran a README link-check script across all `library/plug-*` READMEs after the changes: 56 link occurrences checked, 22 unique external URLs, 0 broken links.
